### PR TITLE
Add calendar ability to the bot

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "sourceType": "module"
+    },
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/commands/announce_events_happening_today.js
+++ b/commands/announce_events_happening_today.js
@@ -1,0 +1,53 @@
+/**
+ * Every morning, announce upcoming events for the day, and
+ * events that are due tomorrow.
+ *
+ * @author Yaw Boakye <wheresyaw@gmail.com>
+ */
+'use strict';
+
+const config = require('../config');
+const getEventsHappeningToday = require('../helpers').getEventsHappeningToday;
+const pluralize = require('../helpers').pluralize;
+
+module.exports = (channel, iconUrl, bot) => {
+  return () => {
+    getEventsHappeningToday().
+      then(events => {
+        if (events.length) {
+          let i, event,
+              attachments = [],
+              text = `${pluralize(events.length, 'event')} happening today:`;
+
+          for (i = 0; i < events.length; i++) {
+            event = events[i];
+
+            attachments.push({
+              fields: [
+                { title: 'Location', value: event.location },
+                { title: 'Start At', value: event.start, short: true },
+                { title: 'Ends At', value: event.end, short: true },
+                { title: 'Description', value: event.description }
+              ],
+
+              title: event.summary,
+              title_link: event.htmlLink,
+              author_name: event.creator.displayName,
+              author_url: `mailto:${event.creator.email}`,
+              color: config.ATTACHMENT_COLOR
+            });
+          }
+
+          bot.api.chat.postMessage({
+            text,
+            channel,
+            attachments,
+            as_user: false,
+            icon_emoji: ':calendar:',
+            username: bot.identity.name
+          });
+        }
+      }).
+      catch(err => console.error(err));
+  };
+};

--- a/commands/announce_events_happening_tomorrow.js
+++ b/commands/announce_events_happening_tomorrow.js
@@ -1,0 +1,53 @@
+/**
+ * Every morning, announce upcoming events for the day, and
+ * events that are due tomorrow.
+ *
+ * @author Yaw Boakye <wheresyaw@gmail.com>
+ */
+'use strict';
+
+const config = require('../config');
+const getEventsHappeningTomorrow = require('../helpers').getEventsHappeningTomorrow;
+const pluralize = require('../helpers').pluralize;
+
+module.exports = (channel, iconUrl, bot) => {
+  return () => {
+    getEventsHappeningTomorrow().
+      then(events => {
+        if (events.length) {
+          let i, event,
+              attachments = [],
+              text = `${pluralize(events.length, 'event')} happening tomorrow:`;
+
+          for (i = 0; i < events.length; i++) {
+            event = events[i];
+
+            attachments.push({
+              fields: [
+                { title: 'Location', value: event.location },
+                { title: 'Start At', value: event.start, short: true },
+                { title: 'Ends At', value: event.end, short: true },
+                { title: 'Description', value: event.description }
+              ],
+
+              title: event.summary,
+              title_link: event.htmlLink,
+              author_name: event.creator.displayName,
+              author_url: `mailto:${event.creator.email}`,
+              color: config.ATTACHMENT_COLOR
+            });
+          }
+
+          bot.api.chat.postMessage({
+            text,
+            channel,
+            attachments,
+            as_user: false,
+            icon_emoji: ':calendar:',
+            username: bot.identity.name
+          });
+        }
+      }).
+      catch(err => console.error(err));
+  };
+};

--- a/commands/get_astronomy_picture_of_the_day.js
+++ b/commands/get_astronomy_picture_of_the_day.js
@@ -35,5 +35,5 @@ module.exports = (channel, iconUrl, bot) => {
         });
       }).
       catch(err => console.error(err));
-  }
+  };
 };

--- a/config.js
+++ b/config.js
@@ -2,4 +2,6 @@ module.exports = {
   ATTACHMENT_COLOR: '#4abfa4',
   APOD_API_URL: `https://api.nasa.gov/planetary/apod?api_key=${process.env.APOD_API_KEY}`,
   APOD_WEB_URL: 'https://apod.nasa.gov/apod/astropix.html',
-}
+  GCAL_API_KEY: process.env.GCAL_API_KEY,
+  GHANA_TECH_CAL_ID: process.env.GHANA_TECH_CAL_ID
+};

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ATTACHMENT_COLOR: "#4abfa4",
+  ATTACHMENT_COLOR: '#4abfa4',
   APOD_API_URL: `https://api.nasa.gov/planetary/apod?api_key=${process.env.APOD_API_KEY}`,
   APOD_WEB_URL: 'https://apod.nasa.gov/apod/astropix.html',
 }

--- a/helpers.js
+++ b/helpers.js
@@ -4,6 +4,7 @@ const request = require('request');
 const random_ua = require('random-ua');
 const cheerio = require('cheerio');
 const config = require('./config');
+const gcal = require('googleapis').calendar('v3');
 
 /**
  * Create a helper method to strip ',' from amount and return number to 2 decimals
@@ -14,7 +15,85 @@ function stripCommas(invalidNumber) {
   return parseFloat(invalidNumber.replace(',', '').trim()).toFixed(2);
 }
 
+/**
+ * getStartOfDay returns the Date object for the start of day of a specific date/time.
+ * @param {Date} datetime
+ * @return Date
+ */
+function getStartOfDay(datetime) {
+  const day = new Date(datetime);
+  day.setHours(0);
+  day.setMinutes(0);
+  day.setSeconds(0);
+  day.setMilliseconds(0);
+
+  return day;
+}
+
+/**
+ * getNextDay returns date after `datetime`.
+ * @param {Date} datetime
+ * @return Date
+ */
+function getNextDay(datetime) {
+  const day = getStartOfDay(datetime);
+  day.setHours(24);
+
+  return day;
+}
+
+function getEventsFor(when) {
+  if (when !== 'today' && when !== 'tomorrow') return;
+
+  let timeMax, timeMin, now = new Date;
+
+  if (when === 'today') {
+    timeMax = getNextDay(now).toISOString();
+    timeMin = getStartOfDay(now).toISOString();
+  } else {
+    timeMax = getNextDay(getNextDay(now)).toISOString();
+    timeMin = getNextDay(now).toISOString();
+  }
+
+  return new Promise((resolve, reject) => {
+    gcal.events.list({
+        timeMax,
+        timeMin,
+        auth: config.GCAL_API_KEY,
+        calendarId: config.GHANA_TECH_CAL_ID
+      },
+      callback(resolve, reject)
+    );
+  });
+
+
+  function callback(resolve, reject) {
+    return function(err, data) {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(data.items);
+    };
+  }
+}
+
+getEventsFor('today');
+
 module.exports = {
+  /**
+   * `pluralize` is a poor man's pluralize. Without any inflectors it just
+   * assumes that adding `s` to the end of the string is the correct plural.
+   * If that doesn't apply to the word you want to pluralize, please avoid
+   * at all cost
+   *
+   * @param {Number} count
+   * @param {String} word
+   * @return {String}
+   */
+  pluralize(count, word) {
+    Math.abs(count) === 1 ? String(word) : String(word) + 's';
+  },
+
   /**
    * Create a helper method to handle slack user handle creation
    * @param  string userId
@@ -42,7 +121,7 @@ module.exports = {
           // Parse HTML with cheerio
           let $ = cheerio.load(html);
           // jQuery style selector
-          let result = $('tr.uccRes').children('td.rightCol').text().replace("GHS", "").replace(/\s\s*$/, '');
+          let result = $('tr.uccRes').children('td.rightCol').text().replace('GHS', '').replace(/\s\s*$/, '');
           // resolve promise if successful
           resolve({
             amount: `GH¢ ${result}`,
@@ -52,7 +131,7 @@ module.exports = {
           // reject if an error, false for if there was no error but status code wasn't 200
           reject(error || false);
         }
-      })
+      });
     });
   },
 
@@ -96,7 +175,7 @@ module.exports = {
           // reject if an error, false for if there was no error but status code wasn't 200
           return reject(error || false);
         }
-      })
+      });
     });
   },
 
@@ -108,10 +187,13 @@ module.exports = {
           // I think I could be more careful and surround `JSON.parse` with a
           // try...catch in case unexpectedly we get something back that's not
           // a JSON string.
-          return resolve(JSON.parse(body))
+          return resolve(JSON.parse(body));
         }
         return reject(error);
       });
     });
-  }
+  },
+
+  getEventsHappeningToday() { return getEventsFor('today'); },
+  getEventsHappeningTomorrow() { return getEventsFor('tomorrow'); }
 };

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ if (!process.env.token) {
 let appName = 'MyApp';
 let channelIdForGeneral = '';
 let channelIdForRandom = '';
+let channelIdForEvents = '';
 let iconUrl = '';
 
 if (process.env.appName) {
@@ -38,6 +39,10 @@ if (process.env.generalId) {
 
 if (process.env.randomId) {
   channelIdForRandom = process.env.randomId;
+}
+
+if (process.env.eventsId) {
+  channelIdForEvents = process.env.eventsId;
 }
 
 if (process.env.iconUrl) {
@@ -68,11 +73,15 @@ let definitionCommand = require('./commands/definition')();
 let goodMorningGreetingCommand = greetingCommand(channelIdForGeneral, iconUrl, bot);
 let goodNightGreetingCommand = greetingCommand(channelIdForGeneral, iconUrl, bot, `Good night ${appName}`);
 let getAstronomyPictureOfTheDayCommand = require('./commands/get_astronomy_picture_of_the_day')(channelIdForRandom, iconUrl, bot);
+let announceEventsHappeningTodayCommand = require('./commands/announce_events_happening_today')(channelIdForEvents, iconUrl, bot);
+let announceEventsHappeningTomorrowCommand = require('./commands/announce_events_happening_tomorrow')(channelIdForEvents, iconUrl, bot);
 
 // scheduled messages
 schedule.scheduleJob('30 9 * * *', goodMorningGreetingCommand);
-schedule.scheduleJob('30 23 * * *', goodNightGreetingCommand);
+schedule.scheduleJob('31 9 * * *', announceEventsHappeningTodayCommand);
 schedule.scheduleJob('0 13 * * *', getAstronomyPictureOfTheDayCommand);
+schedule.scheduleJob('0 16 * * *', announceEventsHappeningTomorrowCommand);
+schedule.scheduleJob('30 23 * * *', goodNightGreetingCommand);
 
 // Welcome command
 controller.on('user_channel_join', welcomeCommand);

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "engines": {
     "node": "6.3.1"
+  },
+  "devDependencies": {
+    "eslint": "^3.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "botkit": "^0.2.2",
     "cheerio": "^0.20.0",
+    "googleapis": "^14.1.0",
     "node-schedule": "^1.1.1",
     "random-ua": "0.0.6",
     "request": "^2.74.0"


### PR DESCRIPTION
The new commands (2 of them) allow the bot to announce in the #events
channel, at 9.31AM events happening during the day, and at 4.30PM, events
happening tomorrow.

Unfortunately, I haven't tested to make sure it works well with Slack but
it's fetching the data alright from Google. @silentwork and
@oddoye-david please take several passes over it before approving.

Addresses https://github.com/devcongress/slackbot/issues/24
