### PR TITLE
Webhooks server

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ module.exports = {
   GENERAL_ID: process.env.GENERAL_ID || '',
   RANDOM_ID: process.env.RANDOM_ID || '',
   EVENTS_ID: process.env.EVENTS_ID || '',
+  RUBY_ID: process.env.RUBY_ID || '',
   ICON_URL: process.env.ICON_URL || '',
   API_AI_TOKEN: process.env.API_AI_TOKEN,
   DICTIONARY_API_BASE_URL: 'https://owlbot.info/api/v1/dictionary',

--- a/index.js
+++ b/index.js
@@ -56,6 +56,9 @@ if (process.env.NODE_ENV == 'development') {
 
   // Schedule Jobs
   require('./jobs')(scheduler, bot);
+
+  // Initialise Webhooks server
+  require('./webhooks/server')(bot);
 }
 
 // Initialise Command Listeners

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "license": "MIT",
   "dependencies": {
     "apiai": "^3.0.3",
+    "body-parser": "^1.17.1",
     "botkit": "^0.5.2",
     "cheerio": "^0.20.0",
     "date-fns": "^1.28.1",
     "dotenv": "^4.0.0",
+    "express": "^4.15.2",
     "googleapis": "^14.1.0",
     "node-schedule": "^1.1.1",
     "random-ua": "0.0.6",

--- a/webhooks/routes.js
+++ b/webhooks/routes.js
@@ -1,0 +1,38 @@
+module.exports = (bot) => {
+  const config = require('../config');
+  const { Router } = require('express');
+
+  const router = Router();
+
+  router.post('/github', (req, res) => {
+    const { action, number, pull_request, repository } = req.body;
+
+    if(action === 'opened') {
+      const message = `Pull Request #${number} opened on *${repository.full_name}*`;
+      const payload = {
+        icon_url: config.ICON_URL,
+        channel: config.RUBY_ID,
+        username: bot.identity.name,
+        as_user: false,
+        attachments: [{
+          author_name: pull_request.user.login,
+          color: config.ATTACHMENT_COLOR,
+          title: 'View on Github',
+          title_link: pull_request.html_url,
+          text: pull_request.title,
+          pretext: message,
+          mrkdwn_in: ['text', 'pretext'],
+          footer: 'Github',
+          footer_icon: 'http://www.zib.de/miltenberger/github-icon.png'
+        }],
+      };
+
+      bot.say(payload);
+    }
+
+    res.status(200).end();
+  });
+
+  return router;
+};
+

--- a/webhooks/routes.js
+++ b/webhooks/routes.js
@@ -4,10 +4,10 @@ module.exports = (bot) => {
 
   const router = Router();
 
-  router.post('/github', (req, res) => {
+  router.post('/github/elections-api', (req, res) => {
     const { action, number, pull_request, repository } = req.body;
 
-    if(action === 'opened') {
+    if(action === 'opened' || action === 'reopened') {
       const message = `Pull Request #${number} opened on *${repository.full_name}*`;
       const payload = {
         icon_url: config.ICON_URL,

--- a/webhooks/server.js
+++ b/webhooks/server.js
@@ -1,0 +1,22 @@
+module.exports = (bot) => {
+  const express = require('express');
+  const bodyParser = require('body-parser');
+  const routes = require('./routes')(bot);
+
+
+  const PORT = process.env.PORT || 3000;
+  const app = express();
+
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({
+    extended: true,
+  }));
+
+  app.use('/webhooks', routes);
+
+  app.listen(PORT, (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+};


### PR DESCRIPTION
Implemented [express](https://expressjs.com/) server to listen to incoming webhooks and send appropriate messages. Currently implemented for sending messages to the #ruby channel on the event of opening/reopening a PR on [elections-api](https://github.com/devconhttps://expressjs.com/gress/elections-api)